### PR TITLE
Implement foundation for the Manage Campaign CVR action.

### DIFF
--- a/src/target-agents/base.ts
+++ b/src/target-agents/base.ts
@@ -29,7 +29,7 @@ export class TargetAgent extends ApiHelper {
     identifier: string,
     type: string,
     action: string,
-    evaluation: boolean | number,
+    evaluation: boolean,
     params: Object
   ) {
     throw new Error('process() method not implemented.');
@@ -39,7 +39,7 @@ export class TargetAgent extends ApiHelper {
     identifier: string,
     type: string,
     action: string,
-    evaluation: boolean | number,
+    evaluation: boolean,
     params: Object
   ): string[] {
     throw new Error('validate() method not implemented.');

--- a/src/target-agents/base.ts
+++ b/src/target-agents/base.ts
@@ -29,18 +29,20 @@ export class TargetAgent extends ApiHelper {
     identifier: string,
     type: string,
     action: string,
-    evaluation: boolean,
+    evaluation: boolean | number,
     params: Object
-  ) {}
+  ) {
+    throw new Error('process() method not implemented.');
+  }
 
   validate(
     identifier: string,
     type: string,
     action: string,
-    evaluation: boolean,
+    evaluation: boolean | number,
     params: Object
   ): string[] {
-    throw new Error('Method not implemented.');
+    throw new Error('validate() method not implemented.');
   }
 
   /**

--- a/src/target-agents/dv360.ts
+++ b/src/target-agents/dv360.ts
@@ -67,14 +67,14 @@ export class DV360 extends TargetAgent {
    * @param {string} identifier
    * @param {DV360_ENTITY_TYPE} type
    * @param {DV360_ACTION} action
-   * @param {boolean} evaluation
+   * @param {boolean | number} evaluation
    * @param {Parameters} params Additional parameters
    */
   process(
     identifier: string,
     type: DV360_ENTITY_TYPE,
     action: DV360_ACTION,
-    evaluation: boolean,
+    evaluation: boolean | number,
     params: Parameters
   ) {
     // Check for missing parameters
@@ -84,7 +84,7 @@ export class DV360 extends TargetAgent {
     this.authToken = auth.getAuthToken();
 
     if (action === DV360_ACTION.TOGGLE) {
-      return this.handleToggle(identifier, type, evaluation, params);
+      return this.handleToggle(identifier, type, evaluation as boolean, params);
     } else {
       throw new Error(
         `Action '${action}' not supported in '${DV360.friendlyName}' agent`
@@ -119,7 +119,7 @@ export class DV360 extends TargetAgent {
    * @param {string} identifier
    * @param {DV360_ENTITY_TYPE} type
    * * @param {DV360_ACTION} action
-   * @param {boolean} evaluation
+   * @param {boolean | number} evaluation
    * @param {Parameters} params Additional parameters
    * @returns {string[]}
    */
@@ -127,7 +127,7 @@ export class DV360 extends TargetAgent {
     identifier: string,
     type: DV360_ENTITY_TYPE,
     action: DV360_ACTION,
-    evaluation: boolean,
+    evaluation: boolean | number,
     params: Parameters
   ) {
     // Check for missing parameters
@@ -145,7 +145,7 @@ export class DV360 extends TargetAgent {
       status = this.isInsertionOrderActive(params.advertiserId, identifier);
     }
 
-    if (evaluation !== status) {
+    if ((evaluation as boolean) !== status) {
       errors.push(
         `Status for ${identifier} (${type}) should be ${evaluation} but is ${status}`
       );

--- a/src/target-agents/dv360.ts
+++ b/src/target-agents/dv360.ts
@@ -67,14 +67,14 @@ export class DV360 extends TargetAgent {
    * @param {string} identifier
    * @param {DV360_ENTITY_TYPE} type
    * @param {DV360_ACTION} action
-   * @param {boolean | number} evaluation
+   * @param {boolean} evaluation
    * @param {Parameters} params Additional parameters
    */
   process(
     identifier: string,
     type: DV360_ENTITY_TYPE,
     action: DV360_ACTION,
-    evaluation: boolean | number,
+    evaluation: boolean,
     params: Parameters
   ) {
     // Check for missing parameters
@@ -84,7 +84,7 @@ export class DV360 extends TargetAgent {
     this.authToken = auth.getAuthToken();
 
     if (action === DV360_ACTION.TOGGLE) {
-      return this.handleToggle(identifier, type, evaluation as boolean, params);
+      return this.handleToggle(identifier, type, evaluation, params);
     } else {
       throw new Error(
         `Action '${action}' not supported in '${DV360.friendlyName}' agent`
@@ -119,7 +119,7 @@ export class DV360 extends TargetAgent {
    * @param {string} identifier
    * @param {DV360_ENTITY_TYPE} type
    * * @param {DV360_ACTION} action
-   * @param {boolean | number} evaluation
+   * @param {boolean} evaluation
    * @param {Parameters} params Additional parameters
    * @returns {string[]}
    */
@@ -127,7 +127,7 @@ export class DV360 extends TargetAgent {
     identifier: string,
     type: DV360_ENTITY_TYPE,
     action: DV360_ACTION,
-    evaluation: boolean | number,
+    evaluation: boolean,
     params: Parameters
   ) {
     // Check for missing parameters
@@ -145,7 +145,7 @@ export class DV360 extends TargetAgent {
       status = this.isInsertionOrderActive(params.advertiserId, identifier);
     }
 
-    if ((evaluation as boolean) !== status) {
+    if (evaluation !== status) {
       errors.push(
         `Status for ${identifier} (${type}) should be ${evaluation} but is ${status}`
       );

--- a/src/target-agents/google-ads.ts
+++ b/src/target-agents/google-ads.ts
@@ -33,6 +33,7 @@ export enum GOOGLE_ADS_ENTITY_STATUS {
 
 export enum GOOGLE_ADS_ACTION {
   TOGGLE = 'Enable/Pause',
+  MANAGE_CONV_VALUE_RULE = 'Manage Conv. Value Rule',
 }
 
 interface Parameters {
@@ -40,6 +41,8 @@ interface Parameters {
   developerToken: string;
   loginCustomerId?: string;
   serviceAccount?: ServiceAccount;
+  geo?: string;
+  conversionWeight?: number;
 }
 
 interface Entity {
@@ -89,6 +92,8 @@ export class GoogleAds extends TargetAgent {
 
     if (action === GOOGLE_ADS_ACTION.TOGGLE) {
       return this.handleToggle(identifier, type, evaluation, params);
+    } else if (action === GOOGLE_ADS_ACTION.MANAGE_CONV_VALUE_RULE) {
+      this.handleAddingConversionRule(identifier, evaluation, params);
     } else {
       throw new Error(
         `Action '${action}' not supported in '${GoogleAds.friendlyName}' agent`
@@ -145,6 +150,22 @@ export class GoogleAds extends TargetAgent {
     } else if (type === GOOGLE_ADS_SELECTOR_TYPE.CAMPAIGN_LABEL) {
       this.updateCampaignsByLabel(params.customerId, identifier, status);
     }
+  }
+
+  handleAddingConversionRule(
+    identifier: string,
+    evaluation: boolean,
+    params: Parameters
+  ) {
+    if (params.conversionWeight === undefined) {
+      throw new Error('A conversion weight target value was not provided.');
+    }
+
+    const weight: number = evaluation
+      ? params.conversionWeight
+      : params.conversionWeight * -1;
+
+    console.log(`Conversion weight to apply:  ${weight}`);
   }
 
   /**

--- a/src/target-agents/google-ads.ts
+++ b/src/target-agents/google-ads.ts
@@ -165,11 +165,7 @@ export class GoogleAds extends TargetAgent {
       throw new Error('The geo target param value was not provided.');
     }
 
-    const weight: number = evaluation
-      ? 1 + params.conversionWeight
-      : 1 + params.conversionWeight * -1;
-
-    console.log(`Conversion weight to apply:  ${weight}`);
+    console.log(`Conversion weight to apply to CVR:  ${evaluation}`);
   }
 
   /**

--- a/src/target-agents/google-ads.ts
+++ b/src/target-agents/google-ads.ts
@@ -72,14 +72,14 @@ export class GoogleAds extends TargetAgent {
    * @param {string} identifier
    * @param {GOOGLE_ADS_SELECTOR_TYPE} type
    * @param {GOOGLE_ADS_ACTION} action
-   * @param {boolean | number} evaluation
+   * @param {boolean} evaluation
    * @param {Parameters} params Additional parameters
    */
   process(
     identifier: string,
     type: GOOGLE_ADS_SELECTOR_TYPE,
     action: GOOGLE_ADS_ACTION,
-    evaluation: boolean | number,
+    evaluation: boolean,
     params: Parameters
   ) {
     // Check for missing parameters
@@ -91,9 +91,9 @@ export class GoogleAds extends TargetAgent {
     this.parameters = params;
 
     if (action === GOOGLE_ADS_ACTION.TOGGLE) {
-      return this.handleToggle(identifier, type, evaluation as boolean, params);
+      return this.handleToggle(identifier, type, evaluation, params);
     } else if (action === GOOGLE_ADS_ACTION.MANAGE_CONV_VALUE_RULE) {
-      this.handleAddingConversionRule(identifier, evaluation as number, params);
+      this.handleAddingConversionRule(identifier, evaluation, params);
     } else {
       throw new Error(
         `Action '${action}' not supported in '${GoogleAds.friendlyName}' agent`
@@ -154,7 +154,7 @@ export class GoogleAds extends TargetAgent {
 
   handleAddingConversionRule(
     identifier: string,
-    evaluation: number,
+    evaluation: boolean,
     params: Parameters
   ) {
     if (params.conversionWeight === undefined) {

--- a/src/target-agents/google-ads.ts
+++ b/src/target-agents/google-ads.ts
@@ -72,14 +72,14 @@ export class GoogleAds extends TargetAgent {
    * @param {string} identifier
    * @param {GOOGLE_ADS_SELECTOR_TYPE} type
    * @param {GOOGLE_ADS_ACTION} action
-   * @param {boolean} evaluation
+   * @param {boolean | number} evaluation
    * @param {Parameters} params Additional parameters
    */
   process(
     identifier: string,
     type: GOOGLE_ADS_SELECTOR_TYPE,
     action: GOOGLE_ADS_ACTION,
-    evaluation: boolean,
+    evaluation: boolean | number,
     params: Parameters
   ) {
     // Check for missing parameters
@@ -91,9 +91,9 @@ export class GoogleAds extends TargetAgent {
     this.parameters = params;
 
     if (action === GOOGLE_ADS_ACTION.TOGGLE) {
-      return this.handleToggle(identifier, type, evaluation, params);
+      return this.handleToggle(identifier, type, evaluation as boolean, params);
     } else if (action === GOOGLE_ADS_ACTION.MANAGE_CONV_VALUE_RULE) {
-      this.handleAddingConversionRule(identifier, evaluation, params);
+      this.handleAddingConversionRule(identifier, evaluation as number, params);
     } else {
       throw new Error(
         `Action '${action}' not supported in '${GoogleAds.friendlyName}' agent`
@@ -154,16 +154,20 @@ export class GoogleAds extends TargetAgent {
 
   handleAddingConversionRule(
     identifier: string,
-    evaluation: boolean,
+    evaluation: number,
     params: Parameters
   ) {
     if (params.conversionWeight === undefined) {
-      throw new Error('A conversion weight target value was not provided.');
+      throw new Error('The conversion weight target param was not provided.');
+    }
+
+    if (params.geo === undefined) {
+      throw new Error('The geo target param value was not provided.');
     }
 
     const weight: number = evaluation
-      ? params.conversionWeight
-      : params.conversionWeight * -1;
+      ? 1 + params.conversionWeight
+      : 1 + params.conversionWeight * -1;
 
     console.log(`Conversion weight to apply:  ${weight}`);
   }

--- a/src/target-agents/google-ads.ts
+++ b/src/target-agents/google-ads.ts
@@ -165,7 +165,9 @@ export class GoogleAds extends TargetAgent {
       throw new Error('The geo target param value was not provided.');
     }
 
-    console.log(`Conversion weight to apply to CVR:  ${evaluation}`);
+    console.log(
+      `Will create/update CVR?:  ${evaluation}, conv. weight ${params.conversionWeight}`
+    );
   }
 
   /**

--- a/test/target-agents/google-ads.test.ts
+++ b/test/target-agents/google-ads.test.ts
@@ -178,7 +178,7 @@ describe('Google Ads Target Agent', () => {
             '1234',
             GOOGLE_ADS_SELECTOR_TYPE.AD_ID,
             GOOGLE_ADS_ACTION.MANAGE_CONV_VALUE_RULE,
-            -1,
+            true,
             manageCvrParams
           );
         }).toThrow(/conversion weight/);
@@ -197,28 +197,10 @@ describe('Google Ads Target Agent', () => {
             '1234',
             GOOGLE_ADS_SELECTOR_TYPE.AD_ID,
             GOOGLE_ADS_ACTION.MANAGE_CONV_VALUE_RULE,
-            -1,
+            true,
             manageCvrParams
           );
         }).toThrow(/geo/);
-      });
-
-      it('Handles numeric evaluation values for updating campaign CVRs', () => {
-        const ads = new GoogleAds();
-        const manageCvrParams = {
-          customerId: '1',
-          developerToken: 'token',
-          geo: 'New York, New York',
-          conversionWeight: 0.25,
-        };
-
-        ads.process(
-          '1234',
-          GOOGLE_ADS_SELECTOR_TYPE.AD_ID,
-          GOOGLE_ADS_ACTION.MANAGE_CONV_VALUE_RULE,
-          -1.0,
-          manageCvrParams
-        );
       });
     });
   });


### PR DESCRIPTION
Provides the building blocks for implementing the Manage Campaign CVR action.  This adds optional params for the geo and conversion weight,  and updates the process() and validate() functions to handle the new manage campaign CVR action.  

The strategy is that when the data pipeline is synced, it'll specify a pace/inventory weight between -1.0 and 1.0 for a specific geo.  If zero is received, then the evaluation value is 'FALSE', and any CVRs for those campaigns are disabled.  If a non-zero value is received, then the evaluation is 'TRUE', and a CVR is added/updated for those campaigns.

Finally, the conversion value param should be set by formula using the weights provided by the pipeline.  The formulas should output a negative value when conversion values should be lowered, creating a pull back strategy (ahead of schedule or little inventory is available).  Or conversely, a positive value means conversion values should be raised, creating an aggressive strategy (behind schedule or lots of inventory is available).